### PR TITLE
Menu 'Touren' is only showed when user has enough rights (incl. WP ad…

### DIFF
--- a/wordpress/wp-content/plugins/bergclub-plugin/Touren/app.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/Touren/app.php
@@ -75,7 +75,7 @@ function bcb_register_my_tourenverwaltung() {
         "has_archive" => false,
         "show_in_menu" => true,
         "exclude_from_search" => false,
-        "capability_type" => "post",
+        "capability_type" => ['tour', 'touren'],
         "map_meta_cap" => true,
         "hierarchical" => false,
         "rewrite" => array( "slug" => "tourenverwaltung", "with_front" => true ),


### PR DESCRIPTION
…min)