### PR TITLE
Add TourenHelper

### DIFF
--- a/wordpress/wp-content/plugins/bergclub-plugin/README.md
+++ b/wordpress/wp-content/plugins/bergclub-plugin/README.md
@@ -8,6 +8,7 @@ bergclub-plugin
 ├── Tests
 ├── vendor
 ├── AssetHelper.php
+├── TourenHelper.php
 ├── bergclub-plugin.php
 ├── composer.json
 ├── FlashMessage.php
@@ -53,6 +54,52 @@ Wird der zweite Parameter nicht verwendet, muss die URL relativ zum `plugins` Ve
 ***Hinweis:** Bei Verwendung des MVC Pattern bitte den AssetHelper nur verwenden um Assets hinzuzufügen die auf allen
 Seiten verwendet werden sollen.*
 
+**TourenHelper.php**
+
+Die statischen methoden des TourenHelper werden über die Funktion `bcb_touren_meta` (in `bergclub-plugin.php`) zur
+Verfügung gestellt.
+
+Als Parameter wird die Post ID und der Meta Key (ohne führendes `_`) benötigt.
+
+Beispiel:
+```
+while ($query->have_posts()) : $query->the_post();
+    $dateFrom = bcb_touren_meta(get_the_ID(), 'dateFrom');
+    [...]
+}
+```
+
+Folgende Meta Keys stehen momentan zur Verfügung (Falls Eintrag nicht gefunden oder keine Zuordnung (id) vorgenommen werden kann, wird `null` zurückgeliefert)
+
+* `dateFrom`: Liefert das "Von" Datum im Format "d.m.Y"
+* `dateTo`: Liefert das "Bis" Datum im Format "d.m.Y" (falls vorhanden)
+* `dateDisplayShort`: Liefert das Datum im Format "d.m." (Eintägig) resp. "d.m. - d.m." (Mehrtägig)
+* `dateDisplayLong`: Liefert das Datum im Format "d.m.Y" (Eintägig) resp. "d.m.Y - d.m.Y" (Mehrtägig)
+* `isSeveralDays`: Liefert true, falls Mehrtägig, ansonsten false
+* `leader`: Liefert Name des Leiters (in DB ist user id gespeichert)
+* `coLeader`: Liefert Name des Co-Leiters (in DB ist user id gespeichert)
+* `signupUntil`: Liefert die Anmeldefrist im Format "d.m.Y"
+* `signupTo`: Liefert den "Anmeldung an" Wert mit Name, E-Mail und Telefonnummern als kommaseparierten String (in DB ist user id gespeichert)
+* `sleepOver`: Liefert die Angaben zur Übernachtung
+* `meetpoint`: Liefert den vordefinierten Treffpunkt (in DB ist id gespeichert), liefert "Anderer Treffpunkt" falls festgelegt.
+* `meetingPointTime`: Liefert die Zeit für den Treffpunkt im Format "G:i"
+* `returnBack`: Liefert die Informationen zur Rückkehr (Freies Textfeld: Zeit, "abends", etc.)
+* `food`: Liefert die Informationen zur Verpflegung.
+* `type`: Liefert die Tourenart (in DB ist slug gespeichert)
+* `requirementsTechnical`: Liefert die technischen Anforderungen (Abhängig von Tourenart)
+* `requirementsConditionsl`: Liefert die konditionellen Anforderungen (in DB ist id gespeichert)
+* `riseUpMeters`: Liefert die Höhenmeter (Aufstieg)
+* `riseDownMeters`: Liefert die Höhenmeter (Abstieg)
+* `duration`: Liefert die Gesamtzeit der Tour (ohne Pausen)
+* `additionalInfo`: Liefert das zusätzliche Informationen (Ersetzt `\n` durch `<br>`) 
+* `training`: Liefert Training (Ja/Nein)
+* `jsEvent`: Liefert J+S-Event (Ja/Nein)
+* `program`: Liefert das Programm (Ersetzt `\n` durch `<br>`)
+* `equipment`: Liefert die Angaben zur Ausrüstung (Ersetzt `\n` durch `<br>`)
+* `mapMaterial`: Liefert die Angaben zum benötigten Kartenmaterial
+* `onlineMap`: Liefert die URL zur Online-Karte
+* `costs`: Liefert die Kosten (Betrag ohne Währung)
+* `costsFor`: Liefert die Angaben wofür die Kosten sind
 
 **bergclub-plugin.php**
 

--- a/wordpress/wp-content/plugins/bergclub-plugin/TourenHelper.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/TourenHelper.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace BergclubPlugin;
+
+use BergclubPlugin\MVC\Models\Option;
+use BergclubPlugin\MVC\Models\User;
+
+/**
+ * Helps to convert the touren post meta data as needed in theme and export.
+ *
+ * Usage example:
+ * ```
+ * while ($query->have_posts()) : $query->the_post();
+ *      $dateFrom = bcb_touren_meta(get_the_ID(), 'dateFrom');
+ *      [...]
+ * }
+ * ```
+ */
+class TourenHelper
+{
+    public static function getDateFrom($postId){
+        return self::getDate(self::getMeta($postId, 'dateFrom'));
+    }
+
+    public static function getDateTo($postId){
+        return self::getDate(self::getMeta($postId, 'dateTo'));
+    }
+
+    public static function getDateDisplayShort($postId){
+        if(self::isSeveralDays($postId)){
+            return self::getDate(self::getMeta($postId, 'dateFrom'), 'd.m.') . ' - ' . self::getDate(self::getMeta($postId, 'dateTo'), 'd.m.');
+        }
+        return self::getDate(self::getMeta($postId, 'dateFrom'), 'd.m.');
+    }
+
+    public static function getDateDisplayFull($postId){
+        if(self::isSeveralDays($postId)){
+            return self::getDate(self::getMeta($postId, 'dateFrom'), 'd.m.Y') . ' - ' . self::getDate(self::getMeta($postId, 'dateTo'), 'd.m.Y');
+        }
+
+        return self::getDate(self::getMeta($postId, 'dateFrom'), 'd.m.Y');
+    }
+
+    private static function isSeveralDays($postId){
+        $dateFrom = self::getDateFrom($postId);
+        $dateTo = self::getDateTo($postId);
+        return !empty($dateTo) && $dateTo != $dateFrom;
+    }
+    public static function getLeader($postId){
+        return self::getUser(self::getMeta($postId, 'leader'));
+    }
+
+    public static function getCoLeader($postId){
+        return self::getUser(self::getMeta($postId, 'coLeader'));
+    }
+
+    public static function getSignupUntil($postId){
+        return self::getDate(self::getMeta($postId, 'signupUntil'));
+    }
+
+
+    public static function getSignupTo($postId){
+        return self::getUser(self::getMeta($postId, 'signupTo'), true);
+    }
+
+    public static function getMeetpoint($postId){
+        $id = self::getMeta($postId, 'meetpoint');
+        if($id == 1){
+            return "Bern HB, Treffpunkt";
+        }elseif($id == 2){
+            return "Bern HB, auf dem Abfahrtsperron";
+        }elseif($id == 3){
+            return "Bern HB, auf der Welle";
+        }
+
+        $meetpoint = trim(self::getMeta($postId, 'meetpointDifferent'));
+        if(!empty($meetpoint)){
+            return $meetpoint;
+        }
+
+        return null;
+    }
+
+    public static function getType($postId){
+        $slug =  self::getMeta($postId, 'type');
+        $tourenarten = Option::get('tourenarten');
+        if(isset($tourenarten[$slug])){
+            return $tourenarten[$slug];
+        }
+
+        return null;
+    }
+
+    public static function getRequirementsConditional($postId){
+        $id =  self::getMeta($postId, 'requirementsConditional');
+        if($id == 1){
+            return "Leicht";
+        }elseif($id == 2){
+            return "Mittel";
+        }elseif($id == 3){
+            return "Schwer";
+        }
+
+        return null;
+    }
+
+    public static function getAdditionalInfo($postId){
+        return nl2br(self::getMeta($postId, 'additionalInfo'));
+    }
+
+    public static function getTraining($postId){
+        return self::getYesNo(self::getMeta($postId, 'training'));
+    }
+
+    public static function getJsEvent($postId){
+        return self::getYesNo(self::getMeta($postId, 'jsEvent'));
+    }
+
+    public static function getProgram($postId){
+        return nl2br(self::getMeta($postId, 'program'));
+    }
+
+    public static function getEquipment($postId){
+        return nl2br(self::getMeta($postId, 'equipment'));
+    }
+
+    public static function __callStatic($method, $args){
+        $metaKey = substr($method, 3);
+        $metaKey = strtolower(substr($metaKey, 0, 1)) . substr($metaKey, 1);
+        return self::getMeta($args[0], $metaKey);
+    }
+
+    private static function getYesNo($value){
+        return $value ? "Ja" : "Nein";
+    }
+
+    private static function getUser($id, $contact = false){
+        $user = User::find($id);
+        if($user){
+            $result = [$user->last_name . ' ' . $user->first_name];
+            if($contact){
+                if($user->email){
+                    $result[] = bcb_email($user->email);
+                }
+                if($user->phone_private){
+                    $result[] = $user->phone_private . " (P)";
+                }
+                if($user->phone_work){
+                    $result[] = $user->phone_work . " (G)";
+                }
+                if($user->phone_mobile){
+                    $result[] = $user->phone_mobile . " (M)";
+                }
+            }
+            return join(', ', $result);
+        }
+
+        return null;
+    }
+
+    private static function getDate($date, $format = "d.m.Y"){
+        $date = strtotime($date);
+        if($date > 0){
+            return date($format, $date);
+        }
+
+        return null;
+    }
+
+    private static function getMeta($postId, $key){
+        return get_post_meta($postId, '_' . $key, true);
+    }
+}

--- a/wordpress/wp-content/plugins/bergclub-plugin/bergclub-plugin.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/bergclub-plugin.php
@@ -146,3 +146,8 @@ function bcb_change_post_object() {
 
 add_action( 'admin_menu', 'bcb_change_post_label' );
 add_action( 'init', 'bcb_change_post_object' );
+
+function bcb_touren_meta($postId, $metaKey){
+    $method = "get" . strtoupper(substr($metaKey, 0, 1)) . substr($metaKey, 1);
+    return \BergclubPlugin\TourenHelper::$method($postId);
+}

--- a/wordpress/wp-content/themes/bergclub-theme/functions.php
+++ b/wordpress/wp-content/themes/bergclub-theme/functions.php
@@ -250,15 +250,6 @@ function bcb_register_custom_post_types() {
 
 add_action( 'init', 'bcb_register_custom_post_types' );
 
-
-function bcb_get_touren_type_by_slug($slug){
-    $tourenTypes = get_option('bcb_tourenarten');
-    if(isset($tourenTypes[$slug])) {
-        return $tourenTypes[$slug];
-    }
-    return "";
-}
-
 //include bootstrap navigation walker
 require_once('inc/wp_bootstrap_navwalker.php');
 

--- a/wordpress/wp-content/themes/bergclub-theme/index.php
+++ b/wordpress/wp-content/themes/bergclub-theme/index.php
@@ -43,20 +43,15 @@ get_header() ?>
                                 'compare' => '>='
                             )
                         ));
-                        while ($query->have_posts()) : $query->the_post();
-                            $date_from = get_post_meta(get_the_ID(), "_dateFrom", true);
-                            $date_to =  get_post_meta(get_the_ID(), "_dateTo", true);
-                            $dateDisplay = date("d.m.", strtotime($date_from));
-                            if(!empty($date_to) && $date_to != $date_from){
-                                $dateDisplay .=" - " . date("d.m.", strtotime($date_to));
-                            }
-                            $type = get_post_meta(get_the_ID(), "_type", true);
-                            $reqTechnical = get_post_meta(get_the_ID(), "_requirementsTechnical", true);
-                            $typeDisplay = bcb_get_touren_type_by_slug($type) . ", " . $reqTechnical;
-                            $riseUpDisplay = get_post_meta(get_the_ID(), "_riseUpMeters", true);
-                            $riseDownDisplay = get_post_meta(get_the_ID(), "_riseDownMeters", true);
-                            $durationDisplay = get_post_meta(get_the_ID(), "_duration", true);
 
+                        while ($query->have_posts()) : $query->the_post();
+                            $dateDisplay = bcb_touren_meta(get_the_ID(), 'dateDisplayShort');
+                            $type = bcb_touren_meta(get_the_ID(), 'type');
+                            $reqTechnical = bcb_touren_meta(get_the_ID(), 'requirementsTechnical');
+                            $typeDisplay = bcb_touren_meta(get_the_ID(), 'type') . ", " . $reqTechnical;
+                            $riseUpDisplay = bcb_touren_meta(get_the_ID(), "riseUpMeters");
+                            $riseDownDisplay = bcb_touren_meta(get_the_ID(), "riseDownMeters");
+                            $durationDisplay = bcb_touren_meta(get_the_ID(), "duration");
                         ?>
                             <li class="list-group-item add-link">
                                 <div class="row">


### PR DESCRIPTION
Ermöglicht über die funktion bcb_touren_meta die Metadaten so zu erhalten wie sie angezeigt werden müssen (anstelle IDs, slugs, etc).

Benötigt für Theme und Export.

Weitere Infos siehe plugin README.
