### PR TITLE
Fix show bcb jugend or both

### DIFF
--- a/wordpress/wp-content/plugins/bergclub-plugin/Adressverwaltung/activate_functionary_roles.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/Adressverwaltung/activate_functionary_roles.php
@@ -25,6 +25,7 @@ $functionaryRoles = [
             'delete_others_tour' => false,
             'read_private_tour' => false,
             'read_tour' => true,
+            'touren_bcb' => true,
 
             'create_tourenbericht' => true,
             'publish_tourenbericht' => false,
@@ -68,6 +69,7 @@ $functionaryRoles = [
             'delete_others_tour' => false,
             'read_private_tour' => false,
             'read_tour' => true,
+            'touren_jugend' => true,
 
             'create_tourenbericht' => true,
             'publish_tourenbericht' => false,
@@ -110,6 +112,7 @@ $functionaryRoles = [
             'delete_others_tour' => true,
             'read_private_tour' => true,
             'read_tour' => true,
+            'touren_bcb' => true,
 
             'create_tourenbericht' => true,
             'publish_tourenbericht' => true,
@@ -158,6 +161,7 @@ $functionaryRoles = [
             'delete_others_tour' => true,
             'read_private_tour' => true,
             'read_tour' => true,
+            'touren_jugend' => true,
 
             'create_tourenbericht' => true,
             'publish_tourenbericht' => true,
@@ -217,6 +221,8 @@ $functionaryRoles = [
             'delete_others_tour' => true,
             'read_private_tour' => true,
             'read_tour' => true,
+            'touren_bcb' => true,
+            'touren_jugend' => true,
 
             'create_tourenbericht' => true,
             'publish_tourenbericht' => true,
@@ -348,6 +354,8 @@ $functionaryRoles = [
             'delete_others_tour' => false,
             'read_private_tour' => false,
             'read_tour' => true,
+            'touren_bcb' => true,
+            'touren_jugend' => true,
 
             'publish_tourenbericht' => false,
             'edit_tourenbericht' => true,

--- a/wordpress/wp-content/plugins/bergclub-plugin/TourenHelper.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/TourenHelper.php
@@ -18,6 +18,11 @@ use BergclubPlugin\MVC\Models\User;
  */
 class TourenHelper
 {
+    public static function getIsYouth($postId){
+        $isYouth = ['BCB', 'Jugend', 'Beides'];
+        return $isYouth[self::getMeta($postId, 'isYouth')];
+    }
+
     public static function getDateFrom($postId){
         return self::getDate(self::getMeta($postId, 'dateFrom'));
     }


### PR DESCRIPTION
fix #114

Admin menu "Touren" and "Tourenberichte".
According to capabilities (touren_bcb, touren_jugend):
Showing only BCB or only Jugend tours (including "Beide") or showing all if both capabilities are granted.