### PR TITLE
Update assign functionary roles

### DIFF
--- a/wordpress/wp-content/plugins/bergclub-plugin/Adressverwaltung/Controllers/MainController.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/Adressverwaltung/Controllers/MainController.php
@@ -296,6 +296,11 @@ class MainController extends AbstractController
             Helpers::redirect(str_replace('&edit=1', '', $_SERVER['REQUEST_URI']));
         }
 
+        if(isset($_POST['functionary_roles']) && count($_POST['functionary_roles']) && !$user->email){
+            FlashMessage::add(FlashMessage::TYPE_ERROR, 'Sie müssen dem Adresssatz zuerst eine Emailadresse zuweisen, bevor Funktionsrollen zugewiesen werden können.');
+            Helpers::redirect("?page=" . $_GET['page'] . "&view=detail&tab=data&id=" . $user->ID . "&edit=1");
+        }
+
         foreach($user->functionary_roles as $role){
             /* @var Role $role */
             if(!isset($_POST['functionary_roles']) || !in_array($role->getKey(), $_POST['functionary_roles'])){

--- a/wordpress/wp-content/plugins/bergclub-plugin/MVC/Helpers.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/MVC/Helpers.php
@@ -9,6 +9,7 @@
 namespace BergclubPlugin\MVC;
 
 use BergclubPlugin\MVC\Models\Option;
+use BergclubPlugin\MVC\Models\User;
 
 class Helpers
 {
@@ -73,5 +74,24 @@ class Helpers
             $result = strtoupper(substr($result, 0, 1)) . substr($result, 1);
         }
         return $result;
+    }
+
+    public static function sendPassResetMail(User $user){
+        if($user->user_login && $user->user_email) {
+            $message = "";
+            if ($user->gender == "Herr") {
+                $message = "Lieber " . $user->first_name . "\n\n";
+            } elseif ($user->gender == "Frau") {
+                $message = "Liebe " . $user->first_name . "\n\n";
+            }
+
+            $message .= "Aufgrund deiner Funktion für den Bergclub Bern wurde für dich ein Login erstellt.\n\n";
+            $message .= "Dein Benutzername lautet: " . $user->user_login . "\n\n";
+            $message .= "Bitte besuche den untenstehenden Link und gib deinen Benutzernamen ein, danach erhälst du einen Link per Email unter welchem du dein Passwort setzen kannst.\n\n";
+            $message .= "<" . wp_lostpassword_url() . ">\n\n";
+            $message .= "Beste Grüsse\nBergclub Bern";
+
+            wp_mail('"' . $user->first_name . ' ' . $user->last_name . ' <' . $user->user_email . '>"', "Dein Bergclub Bern Login", $message);
+        }
     }
 }


### PR DESCRIPTION
Assigning functionary role(s) is now only possible if an email address is
set.

When the first functionary role is assigned, the user will receive an
email with a link to the password reset page.

fix #171