### PR TITLE
Update fix logo

### DIFF
--- a/wordpress/wp-content/plugins/bergclub-plugin/TourenHelper.php
+++ b/wordpress/wp-content/plugins/bergclub-plugin/TourenHelper.php
@@ -23,6 +23,10 @@ class TourenHelper
         return $isYouth[self::getMeta($postId, 'isYouth')];
     }
 
+    public static function getIsYouthRaw($postId){
+        return self::getMeta($postId, 'isYouth');
+    }
+
     public static function getDateFrom($postId){
         return self::getDate(self::getMeta($postId, 'dateFrom'));
     }

--- a/wordpress/wp-content/themes/bergclub-theme/single-touren.php
+++ b/wordpress/wp-content/themes/bergclub-theme/single-touren.php
@@ -76,7 +76,7 @@ while (have_posts()) : the_post();
         <div class="row">
             <h1>
                 <?php
-                $isYouth = bcb_touren_meta(get_the_ID(), 'isYouth');
+                $isYouth = bcb_touren_meta(get_the_ID(), 'isYouthRaw');
                 if($isYouth == 1 || $isYouth == 2){
                     ?>
                     <img class="pull-right hidden-xs" src="<?= get_template_directory_uri() ?>/img/bergclub-jugend-sm.png" style="margin-left:20px">


### PR DESCRIPTION
Because the isYouth value was translated in TourenHelper to 'BCB',
'Berclub', 'Beides' - the logo display was broken.